### PR TITLE
Bump futures-preview version to alpha.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["network-programming"]
 edition = "2018"
 
 [dependencies]
-futures-preview = "0.3.0-alpha.11"
+futures-preview = "0.3.0-alpha.13"
 libc = "0.2"
 log = "0.4"
 pretty_env_logger = "0.2"

--- a/src/async_tcp_listener.rs
+++ b/src/async_tcp_listener.rs
@@ -4,7 +4,7 @@ use std::net::ToSocketAddrs;
 use std::os::unix::io::AsRawFd;
 use futures::Poll;
 use futures::Stream;
-use futures::task::LocalWaker;
+use futures::task::Waker;
 use core::pin::Pin;
 
 use crate::AsyncTcpStream;
@@ -32,7 +32,7 @@ pub struct Incoming(TcpListener);
 impl Stream for Incoming {
     type Item = AsyncTcpStream;
 
-    fn poll_next(self: Pin<&mut Self>, waker: &LocalWaker) -> Poll<Option<Self::Item>> {
+    fn poll_next(self: Pin<&mut Self>, waker: &Waker) -> Poll<Option<Self::Item>> {
         debug!("poll_next() called");
 
         let fd = self.0.as_raw_fd();

--- a/src/async_tcp_stream.rs
+++ b/src/async_tcp_stream.rs
@@ -1,12 +1,12 @@
 use std::net::ToSocketAddrs;
 use std::net::TcpStream;
-use std::os::unix::io::AsRawFd;
 use std::io::{self, Read, Write};
+use std::os::unix::io::AsRawFd;
 
 use futures::io::AsyncRead;
 use futures::io::AsyncWrite;
 use futures::io::Error;
-use futures::task::LocalWaker;
+use futures::task::Waker;
 use futures::Poll;
 
 use crate::REACTOR;
@@ -24,8 +24,8 @@ impl AsyncTcpStream {
     }
 
     pub fn from_std(stream: TcpStream) -> Result<AsyncTcpStream, io::Error> {
-    	stream.set_nonblocking(true)?;
-    	Ok(AsyncTcpStream(stream))
+       stream.set_nonblocking(true)?;
+       Ok(AsyncTcpStream(stream))
     }
 }
 
@@ -40,7 +40,7 @@ impl Drop for AsyncTcpStream {
 }
 
 impl AsyncRead for AsyncTcpStream {
-    fn poll_read(&mut self, waker: &LocalWaker, buf: &mut [u8]) -> Poll<Result<usize, Error>> {
+    fn poll_read(&mut self, waker: &Waker, buf: &mut [u8]) -> Poll<Result<usize, Error>> {
         debug!("poll_read() called");
 
         let fd = self.0.as_raw_fd();
@@ -58,7 +58,7 @@ impl AsyncRead for AsyncTcpStream {
 }
 
 impl AsyncWrite for AsyncTcpStream {
-    fn poll_write(&mut self, waker: &LocalWaker, buf: &[u8]) -> Poll<Result<usize, Error>> {
+    fn poll_write(&mut self, waker: &Waker, buf: &[u8]) -> Poll<Result<usize, Error>> {
         debug!("poll_write() called");
 
         let fd = self.0.as_raw_fd();
@@ -74,12 +74,12 @@ impl AsyncWrite for AsyncTcpStream {
         }
     }
 
-    fn poll_flush(&mut self, _lw: &LocalWaker) -> Poll<Result<(), Error>> {
+    fn poll_flush(&mut self, _lw: &Waker) -> Poll<Result<(), Error>> {
         debug!("poll_flush() called");
         Poll::Ready(Ok(()))
     }
 
-    fn poll_close(&mut self, _lw: &LocalWaker) -> Poll<Result<(), Error>> {
+    fn poll_close(&mut self, _lw: &Waker) -> Poll<Result<(), Error>> {
         debug!("poll_close() called");
         Poll::Ready(Ok(()))
     }


### PR DESCRIPTION
Was trying to run the examples via `cargo +nightly run --example client` and the build got me `futures-preview` `0.3.0-alpha.13`, with which fahrenheit wouldn't build. (Is that how Cargo's SemVer implementation works? I found this surprising)

I _think_ these are the correct changes, as everything builds a-okay and the examples seem to run fine -- but it's probably worth a look from someone who knows the changes better.

As an aside, it might be worthwhile running `cargo fmt` across the crate -- I had to disable it in my editor due to the churn it added to the diff.